### PR TITLE
Backend/delete hearing data

### DIFF
--- a/app.js
+++ b/app.js
@@ -2,6 +2,7 @@ const express = require("express");
 const authRoute = require("./routes/auth");
 const dataRoute = require("./routes/data");
 const cors = require("cors");
+const os = require("os");
 
 const app = express();
 
@@ -16,7 +17,11 @@ app.use("/auth", authRoute);
 app.use("/data", dataRoute);
 
 app.get("/", (req, res) => {
-    res.send("This is the home page");
+    const hostname = os.hostname();
+    res.send({
+        success: true,
+        container: hostname,
+    });
 });
 
 app.get("/info", (req, res) => {

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -13,6 +13,8 @@ services:
       - 3001
     ports:
       - "3001:3001"
+    restart: on-failure
+
   
   frontend:
     container_name: frontend

--- a/routes/data.js
+++ b/routes/data.js
@@ -130,9 +130,17 @@ router.delete("/", async (req, res) => {
 
         const { _id: user } = data;
 
+        let id;
+
+        try {
+            id = ObjectId(_id);
+        } catch (error) {
+            return res.status(400).send(new InvalidBodyResponse("Invalid id"));
+        }
+
         const collection = client.db("geekout-2022").collection("hearing_data");
         const results = await collection.deleteOne({
-            _id: ObjectId(_id),
+            _id: id,
             user,
         });
 

--- a/routes/data.js
+++ b/routes/data.js
@@ -1,8 +1,8 @@
 const express = require("express");
-const { MongoClient, ServerApiVersion } = require("mongodb");
+const { MongoClient, ServerApiVersion, ObjectId } = require("mongodb");
 
 const JWT = require("../utils/jwt");
-const { getData, insertData } = require("../utils/yupSchemas");
+const { getData, insertData, deleteData } = require("../utils/yupSchemas");
 const InvalidBodyResponse = require("../utils/Response/InvalidBodyResponse");
 const InvalidCredentialsResponse = require("../utils/Response/InvalidCredentialsResponse");
 
@@ -53,6 +53,7 @@ router.get("/", async (req, res) => {
     });
 });
 
+// ! Endpoint for inserting data
 router.post("/", async (req, res) => {
     const isSchemaValid = await insertData.isValid(req.body);
 
@@ -94,6 +95,51 @@ router.post("/", async (req, res) => {
                 });
             }
             console.log(result);
+        });
+    });
+});
+
+// ! Endpoint for deleting data
+router.delete("/", async (req, res) => {
+    const isSchemaValid = await deleteData.isValid(req.body);
+
+    // Return an error if the schema is not valid
+    if (!isSchemaValid) {
+        return res.status(400).send(new InvalidBodyResponse("Invalid body"));
+    }
+
+    const { token, _id } = req.body;
+
+    client.connect(async (err) => {
+        if (err) {
+            console.log(err);
+            return res
+                .status(500)
+                .send("Internal Server Error: Client connection error");
+        }
+
+        let data;
+
+        try {
+            data = JWT.verify(token);
+        } catch (error) {
+            return res
+                .status(401)
+                .send(new InvalidCredentialsResponse("Invalid token"));
+        }
+
+        const { _id: user } = data;
+
+        const collection = client.db("geekout-2022").collection("hearing_data");
+        const results = await collection.deleteOne({
+            _id: ObjectId(_id),
+            user,
+        });
+
+        return res.status(201).json({
+            success: true,
+            // Return the number of documents deleted
+            deletedCount: results.deletedCount,
         });
     });
 });

--- a/utils/yupSchemas.js
+++ b/utils/yupSchemas.js
@@ -14,6 +14,11 @@ const yupSchemas = {
         token: yup.string().required(),
         score: yup.number().required(),
     }),
+
+    deleteData: yup.object().shape({
+        token: yup.string().required(),
+        _id: yup.string().required(),
+    }),
 };
 
 module.exports = yupSchemas;


### PR DESCRIPTION
- Added the ability to delete hearing data based on ID. (Read the API documentation for more info)
- Docker: backend service will restart on failure (This means you don't have to restart manually)
- The root endpoint will now return the endpoint (if ran locally) or the container id (if ran using docker)